### PR TITLE
Include racra-wwise

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ These savegame editors can also be a good resource for a list of value addresses
  - [wadutil](https://github.com/stiantoften/wadutil) - A utility to decompress Ratchet & Clank .wad files `C` `Cross-platform`
  - [rac-dvd-toc-parser](https://github.com/maikelwever/rac-dvd-toc-parser) - Simple Python script to get hidden files from PS2 disc image. `Python` `GPL-3.0`
  - [PIFconvert](https://github.com/stiantoften/PIFconvert/) - Converter/parser for PIF files from PS2 editions. `C` `Cross-platform`
+ - [racra-wwise](https://github.com/PythonBlue/racra-wwise) - Scripts for extracting Wwise soundbanks for Rift Apart for PC. `Python` `Cross-platform`
 
 
 ## Spreadsheets with various info


### PR DESCRIPTION
Worked on a set of Python scripts that make it feasible to extract the Wwise soundbanks from the PC port of Rift Apart for PC, as well as a script that tries to replace music specifically. It's niche and rough around the edges, so no worries if this needs to be declined.