### PR TITLE
Add more information about Wrench, update Ghidra extension link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # rac-modding-resources
 
-
 A list of useful resources when modding and/or reverse engineering any of the Ratchet and Clank games.
-
-Might also be of use for other games that share engine code with these games.
 
 Please note that some of the listed tools might be a Work in Progress.
 
@@ -30,8 +27,8 @@ Please note that some of the listed tools might be a Work in Progress.
 These level editors are also a good code reference for the file formats used in the games.
 
  - [Replanetizer](https://github.com/RatchetModding/replanetizer) - Level editor for the PS3 trilogy remasters.  `C#` `WinForms`
+ - [Wrench Editor](https://github.com/chaoticgd/wrench) - A set of modding tools for the PS2 games. Includes a level editor, asset pipeline, save game editor, and more. `C++` `Dear ImGui`
  - [RatchetLevelEditor](https://github.com/badger41/RatchetLevelEditor) - Previous level editor for the PS3 trilogy remasters. `C#` `WinForms`
- - [Wrench Editor](https://github.com/chaoticgd/wrench) - A set of modding tools for the PS2 games. `C++` `Dear ImGui`
 
 
 ## Reimplementations
@@ -49,6 +46,7 @@ Reimplementations that work on modern systems and outside of Playstations.
 
 These savegame editors can also be a good resource for a list of value addresses as used in savegames.
 
+ - [Wrench Save Editor](https://github.com/chaoticgd/wrench) - Save editor for the PS2 versions of R&C, GC, UYA and DL. Included with Wrench. `C++` `Dear ImGui`
  - [Slim's Editor](https://github.com/RatchetModding/slimseditor) - A savegame editor for the Ratchet and Clank games. `Python 3` `Windows` `Linux` `Dear ImGui` `GPL-3.0`
  - [rac-savegame-editor](https://github.com/maikelwever/rac-savegame-editor) - Old version of the savegame editor for the Ratchet and Clank series of games (PS2, PS3, PSVita). `C#` `GTK3` `GPL-3.0`
  - [Ratchet and Clank Save Editor](https://www.nextgenupdate.com/forums/ps3-trophies-game-saves/718082-release-ratchet-clank-save-editor-all-1.html) ([Presumed source](https://github.com/primetime43/Playstation-3-Tools/tree/master/Ratchet%20%26%20Clank%20Into%20the%20Nexus%20Save%20Editor/Red-EyeX32%20-%20Test%20Drive%20Unlimited%202%20Save%20Editor)) - Save editor for all the Ratchet and Clanks `C#` `Winforms`
@@ -59,6 +57,7 @@ These savegame editors can also be a good resource for a list of value addresses
 
 **[`^        back to top        ^`](#)**
 
+ - [Wrench Build Tool](https://github.com/chaoticgd/wrench) - Asset packer/unpacker for the PS2 versions of R&C, GC, UYA and DL. Included with Wrench. `C++` `Windows` `Linux`
  - [ig-tools](https://github.com/doesthisusername/ig-tools) - Tools for modding and reversing Ratchet & Clank (PS4) `Python` `C`
  - [PSArcFS](https://github.com/maikelwever/psarcfs) - A very crude and not very optimized FUSE handler for .psarc files. Supports ZLIB and LZMA compression. `Rust` `Linux` `GPL-3.0`
  - [PSARC reference and tools list](https://www.psdevwiki.com/ps3/PlayStation_archive_(PSARC)) - Doc about PSARC file format and links to tools for dealing with PSARC archives.
@@ -85,20 +84,21 @@ These savegame editors can also be a good resource for a list of value addresses
 
  - [List of reverse engineering resources](https://github.com/wtsxDev/reverse-engineering) - A curated list of awesome reversing resources.
  - [Ghidra](https://github.com/NationalSecurityAgency/ghidra) - A software reverse engineering (SRE) framework. `Cross-platform` `Apache-2.0`
-    - [Ghidra Emotion Engine plugin](https://github.com/beardypig/ghidra-emotionengine) - Ghidra support plugin for the PS2's Emotion Engine.
+    - [Ghidra Emotion Engine plugin](https://github.com/chaoticgd/ghidra-emotionengine-reloaded) - Ghidra support plugin for the PS2's Emotion Engine.
     - [Ghidra PS3 scripts](https://github.com/zecoxao/ps3_ghidra) - A collection of scripts/loaders/plugins for ghidra used to aid ps3 reverse engineering.
  - [PCSX2](https://pcsx2.net/) ([Source code](https://github.com/PCSX2/pcsx2)) - A free and open-source PlayStation 2 (PS2) emulator, with debugger. `Windows` `Linux` `GPL-2.0`
  - [RPCS3](https://rpcs3.net/) ([Source code](https://github.com/RPCS3/rpcs3)) - The world's first free and open-source PlayStation 3 emulator/debugger. `Windows` `Linux` `GPL-2.0`
  - [Cheat Engine](https://www.cheatengine.org/) ([Source code](https://github.com/cheat-engine/cheat-engine/)) - A development environment focused on modding games and applications for personal use. `Windows` `LGPL-2.0`
- - [Scanmem & Game Conqueror](https://github.com/scanmem/scanmem) - A debugging utility and GUI designed to isolate the address of an arbitrary variable in an executing process. `Linux` `GPL-3.0` 
+ - [Scanmem & Game Conqueror](https://github.com/scanmem/scanmem) - A debugging utility and GUI designed to isolate the address of an arbitrary variable in an executing process. `Linux` `GPL-3.0`
 
 ## Miscellaneous
 
 **[`^        back to top        ^`](#)**
 
- - [MobyViewer](https://github.com/CreepNT/MobyViewer) - A tool to view the Moby table of games in real-time. `C++` `Dear Imgui`
+ - [MobyViewer](https://github.com/CreepNT/MobyViewer) - A tool to view the Moby table of games in real-time. `C++` `Dear ImGui`
  - [RacREpo](https://github.com/CreepNT/RacREpo) - Stash repository which contains scripts, tools and documentation. `Public Domain`
  - [RatchetHax](https://github.com/ParadoxEpoch/RatchetHax) - A Node.js based trainer and API for the Ratchet & Clank series. `Cross-platform` `GPL-3.0`
+ - [racdoor](https://github.com/chaoticgd/racdoor) - Software development kit for producing haunted Ratchet & Clank (PS2) save games. `C` `Linux`
 
 # Legal stuff
 


### PR DESCRIPTION
- This adds more entries about Wrench, since I think just having it in the level editor section was quite misleading.
- I've updated the link for the PS2 Ghidra extension to point to the one I'm maintaining as the other one has been abandoned.
- I've added an entry for my racdoor project.
- I've removed a section from the introduction talking about games that share engine code with the R&C games. Since most of these tools are for the PS2 games, which have their own engine, I think this is misleading (the PS2 games do share some renderers with Jak, but it's quite unlikely these tools would be useful for that).